### PR TITLE
Allow creation of an open network

### DIFF
--- a/hassio-wifi-hotspot/README.md
+++ b/hassio-wifi-hotspot/README.md
@@ -42,3 +42,6 @@ fixed_ips:
     ip: 192.168.99.14
 
 ```
+
+If you use ```wpa_passphrase: ''``` then the created network will be open - i.e. devices will be able to connect without supplying a passphrase.
+

--- a/hassio-wifi-hotspot/hostapd.conf
+++ b/hassio-wifi-hotspot/hostapd.conf
@@ -12,12 +12,6 @@ ht_capab=[HT40][SHORT-GI-20][DSSS_CCK-40]
 # No MAC restriction
 macaddr_acl=0
 
-# User WPA / AES
-auth_algs=1
-wpa=2
-wpa_key_mgmt=WPA-PSK
-rsn_pairwise=CCMP
-
 # Require clients to know the network name
 ignore_broadcast_ssid=0
 

--- a/hassio-wifi-hotspot/run.sh
+++ b/hassio-wifi-hotspot/run.sh
@@ -13,7 +13,7 @@ BROADCAST=$(jq --raw-output ".broadcast" $CONFIG_PATH)
 FIXED_IPS=$(jq --raw-output ".fixed_ips" $CONFIG_PATH)
 
 # Enforces required env variables
-required_vars=(SSID WPA_PASSPHRASE CHANNEL ADDRESS NETMASK BROADCAST)
+required_vars=(SSID CHANNEL ADDRESS NETMASK BROADCAST)
 for required_var in "${required_vars[@]}"; do
     if [[ -z ${!required_var} ]]; then
         error=1
@@ -45,9 +45,17 @@ eval "nmcli dev set $INTERFACE managed no"
 # Setup hostapd.conf
 echo "Setup hostapd ..."
 echo "interface=$INTERFACE"$'\n' >> /hostapd.conf
-echo "ssid=$SSID"$'\n' >> /hostapd.conf
-echo "wpa_passphrase=$WPA_PASSPHRASE"$'\n' >> /hostapd.conf
 echo "channel=$CHANNEL"$'\n' >> /hostapd.conf
+echo "ssid=$SSID"$'\n' >> /hostapd.conf
+if [ "${WPA_PASSPHRASE}" == "" ] ; then
+	echo "WARNING: no passphrase configured so creating an open access point"
+else
+	echo "auth_algs=1"$'\n' >> /hostapd.conf
+	echo "wpa=2"$'\n' >> /hostapd.conf
+	echo "wpa_key_mgmt=WPA-PSK"$'\n' >> /hostapd.conf
+	echo "rsn_pairwise=CCMP"$'\n' >> /hostapd.conf
+	echo "wpa_passphrase=$WPA_PASSPHRASE"$'\n' >> /hostapd.conf
+fi
 
 # Setup interface
 echo "Setup interface ..."


### PR DESCRIPTION
This change allows the user to create an open network by setting the configuration option:
```
wpa_passphrase: ''
```
The empty passphrase disables all connection authentication.

Specifying a passphrase (min 8 characters) restores WPA protection.

A warning message is written to the log file if an attempt is made to configure an open network.
